### PR TITLE
Excel Blank Rows Calls mutateBeforeCreate (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ protected function getActions(): array
 }
 ```
 
+### Filter Out Blank Rows
+If you have a spreadsheet which includes blank data [click here to see more](https://thesoftwarepro.com/excel-tips-how-to-fill-blank-cells/), you can filter these out:
+```php
+protected function getActions(): array
+{
+    return [
+        ImportAction::make()
+            ->handleBlankRows(true)
+            ->fields([
+                ImportField::make('project')
+                    ->label('Project')
+                    ->required(),
+            ])
+    ];
+}
+```
+
 ### Field Data Mutation
 you can also manipulate data from row spreadsheet before saving to model
 ```php

--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -31,6 +31,8 @@ class ImportAction extends Action
 
     protected bool $shouldMassCreate = true;
 
+    protected bool $shouldHandleBlankRows = false;
+
     protected array $cachedHeadingOptions = [];
 
     protected null|Closure $handleRecordCreation = null;
@@ -67,6 +69,7 @@ class ImportAction extends Action
                     ->disk('local')
                     ->skipHeader((bool) $data['skipHeader'])
                     ->massCreate($this->shouldMassCreate)
+                    ->handleBlankRows($this->shouldHandleBlankRows)
                     ->mutateBeforeCreate($this->mutateBeforeCreate)
                     ->mutateAfterCreate($this->mutateAfterCreate)
                     ->handleRecordCreation($this->handleRecordCreation)
@@ -102,6 +105,13 @@ class ImportAction extends Action
     public function massCreate($shouldMassCreate = true): static
     {
         $this->shouldMassCreate = $shouldMassCreate;
+
+        return $this;
+    }
+
+    public function handleBlankRows($shouldHandleBlankRows = false): static
+    {
+        $this->shouldHandleBlankRows = $shouldHandleBlankRows;
 
         return $this;
     }


### PR DESCRIPTION
## Proposed changes

So this is linked to #66. Basically, I wanted to add in a way to filter out blank rows (excel blank rows not just rows with no data). Although I feel this would be beneficial to have enabled by default, I didn't want to break peoples own implementations of handling this such as handing this in the `handleRecordCreation()` function although I cannot think of a valid use case where people would want to import these blank rows. I'm happy to be led by maintainers as to if we enable this by default or not, I just didn't want to unleash a potentially breaking change.

I'm happy to provide a spreadsheet which includes these blank rows if you would like to see this.

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [x]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [x]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I will update the documentation now, I also need to run the tests locally (just had a few issues getting them running on my work machine) and I do think it would be beneficial to add in a test which covers these blank rows although I don't think this PR should be dependent on that.