### PR TITLE
Fixes column matching on first field

### DIFF
--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -172,7 +172,7 @@ class ImportAction extends Action
                 }
 
                 $selected = array_search($field->getName(), $options);
-                if ($selected != false) {
+                if ($selected !== false) {
                     $set($field->getName(), $selected);
                 }
 

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -5,6 +5,7 @@ use Konnco\FilamentImport\Tests\Resources\Pages\HandleCreationList;
 use Konnco\FilamentImport\Tests\Resources\Pages\NonRequiredTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\ValidateTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\WithoutMassCreateTestList;
+
 use function Pest\Laravel\assertDatabaseCount;
 
 it('can render import properly', function () {
@@ -118,6 +119,38 @@ it('can ignore non required fields', function () {
         ->assertSuccessful();
 
     assertDatabaseCount(Post::class, 10);
+});
+
+it('can match fields to columns', function () {
+    $file = csvFiles(10, fields:'title,slug,body');
+    livewire(HandleCreationList::class)->mountPageAction('import')
+        ->setPageActionData([
+            'file' => [$file->store('file')],
+            'fileRealPath' => $file->getRealPath(),
+            'skipHeader' => false,
+        ])
+        ->callMountedPageAction()
+        ->assertHasNoPageActionErrors()
+        ->assertSuccessful();
+
+    assertDatabaseCount(Post::class, 11);
+});
+
+it('can match the first field', function () {
+    $file = csvFiles(10, fields:'title,Slug,Body');
+    livewire(HandleCreationList::class)->mountPageAction('import')
+        ->setPageActionData([
+            'file' => [$file->store('file')],
+            'fileRealPath' => $file->getRealPath(),
+            'slug' => 1,
+            'body' => 2,
+            'skipHeader' => false,
+        ])
+        ->callMountedPageAction()
+        ->assertHasNoPageActionErrors()
+        ->assertSuccessful();
+
+    assertDatabaseCount(Post::class, 11);
 });
 
 //it('can manipulate single field', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,11 +13,11 @@ function livewire($list = null)
     return Livewire::test($list ?? CommonTestList::class);
 }
 
-function csvFiles($rows = 10, $extraRow = [])
+function csvFiles($rows = 10, $extraRow = [], $fields='Title,Slug,Body')
 {
     Storage::fake('uploads');
 
-    $content = collect('Title,Slug,Body');
+    $content = collect($fields);
     for ($i = 0; $i < $rows; $i++) {
         $content = $content->push(implode(',', [
             fake()->title,


### PR DESCRIPTION
## Proposed changes

Currently the first field can never be matched due to array_search returning 0 as the key which is then interpreted as falsish. This is mentioned in the [PR](https://github.com/konnco/filament-import/issues/37#issuecomment-1278989210) that added this feature.

This PR changes the check from the loose equal `==` to strict identical `===`.

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [x]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
