### PR TITLE
add alternative column names for automatic matching

### DIFF
--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -168,19 +168,25 @@ class ImportAction extends Action
                 $options = $this->cachedHeadingOptions;
 
                 if (count($options) == 0) {
-                    $options = $this->toCollection($filePath)->first()?->first()->filter(fn ($value) => $value != null)->toArray();
+                    $options = $this->toCollection($filePath)->first()?->first()->filter(fn ($value) => $value != null)->map('trim')->toArray();
                 }
 
                 $selected = array_search($field->getName(), $options);
-                if ($selected != false) {
+
+                if ($selected !== false) {
                     $set($field->getName(), $selected);
+                } elseif (! empty($field->getAlternativeColumnNames())) {
+                    $alternativeNames = array_intersect($field->getAlternativeColumnNames(), $options);
+                    if (count($alternativeNames) > 0) {
+                        $set($field->getName(), array_search(current($alternativeNames), $options));
+                    }
                 }
 
                 return $options;
             });
     }
 
-    public function handleRecordCreation(Closure $closure)
+    public function handleRecordCreation(Closure $closure): static
     {
         $this->handleRecordCreation = $closure;
         $this->massCreate(false);

--- a/src/Actions/ImportField.php
+++ b/src/Actions/ImportField.php
@@ -2,6 +2,7 @@
 
 namespace Konnco\FilamentImport\Actions;
 
+use Konnco\FilamentImport\Concerns\HasColumnMatching;
 use Konnco\FilamentImport\Concerns\HasFieldHelper;
 use Konnco\FilamentImport\Concerns\HasFieldLabel;
 use Konnco\FilamentImport\Concerns\HasFieldMutation;
@@ -17,6 +18,7 @@ class ImportField
     use HasFieldLabel;
     use HasFieldRequire;
     use HasFieldValidation;
+    use HasColumnMatching;
 
     public function __construct(private string $name)
     {

--- a/src/Concerns/HasColumnMatching.php
+++ b/src/Concerns/HasColumnMatching.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Konnco\FilamentImport\Concerns;
+
+trait HasColumnMatching
+{
+    protected ?array $alternativeColumnNames = [];
+
+    public function alternativeColumnNames(array $alternativeColumnNames): static
+    {
+        $this->alternativeColumnNames = $alternativeColumnNames;
+
+        return $this;
+    }
+
+    public function getAlternativeColumnNames(): array
+    {
+        return $this->alternativeColumnNames;
+    }
+}

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Konnco\FilamentImport\Tests\Resources\Models\Post;
+use Konnco\FilamentImport\Tests\Resources\Pages\AlternativeColumnsNamesList;
 use Konnco\FilamentImport\Tests\Resources\Pages\HandleCreationList;
 use Konnco\FilamentImport\Tests\Resources\Pages\NonRequiredTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\ValidateTestList;
@@ -118,6 +119,22 @@ it('can ignore non required fields', function () {
         ->assertSuccessful();
 
     assertDatabaseCount(Post::class, 10);
+});
+
+it('can match alternative column names', function () {
+    $file = csvFiles(10);
+    livewire(AlternativeColumnsNamesList::class)->mountPageAction('import')
+        ->setPageActionData([
+            'file' => [$file->store('file')],
+            'fileRealPath' => $file->getRealPath(),
+            'skipHeader' => false,
+        ])
+        ->assertPageActionDataSet(['title' => 0, 'slug' => 1, 'body' => 2])
+        ->callMountedPageAction()
+        ->assertHasNoPageActionErrors()
+        ->assertSuccessful();
+
+    assertDatabaseCount(Post::class, 11);
 });
 
 //it('can manipulate single field', function () {

--- a/tests/Resources/Pages/AlternativeColumnsNamesList.php
+++ b/tests/Resources/Pages/AlternativeColumnsNamesList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Konnco\FilamentImport\Tests\Resources\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Konnco\FilamentImport\Actions\ImportAction;
+use Konnco\FilamentImport\Actions\ImportField;
+use Konnco\FilamentImport\Tests\Resources\Models\Post;
+use Konnco\FilamentImport\Tests\Resources\PostResource;
+
+class AlternativeColumnsNamesList extends ListRecords
+{
+    protected static string $resource = PostResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            ImportAction::make('import')
+                ->fields([
+                    ImportField::make('title')->alternativeColumnNames(['Title']),
+                    ImportField::make('slug')->alternativeColumnNames(['Slug']),
+                    ImportField::make('body')->alternativeColumnNames(['Body']),
+                ])
+                ->handleRecordCreation(function ($data) {
+                    return Post::create($data);
+                }),
+        ];
+    }
+}


### PR DESCRIPTION
## Proposed changes

In the current way the automatic column matching, the csv header has to match the field name exactly, but sometimes the header might have similar or alternative names for columns, this PR adds the possibility to define alternative names the column might have and hopefully be able to automatically match all columns. 

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ x]  ✨ New feature (non-breaking change which adds functionality)
- [ ]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
