### PR TITLE
Fixes bug where column headings ending with numbers had their numbers removed

### DIFF
--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -18,6 +18,7 @@ use Konnco\FilamentImport\Concerns\HasTemporaryDisk;
 use Konnco\FilamentImport\Import;
 use Livewire\TemporaryUploadedFile;
 use Maatwebsite\Excel\Concerns\Importable;
+use Illuminate\Support\Str;
 
 class ImportAction extends Action
 {
@@ -159,7 +160,7 @@ class ImportAction extends Action
                 $options = $this->cachedHeadingOptions;
 
                 if (count($options) == 0) {
-                    $options = $this->toCollection($filePath)->first()?->first()->filter(fn ($value) => $value != null)->map('trim')->toArray();
+                    $options = $this->toCollection($filePath)->first()?->first()->filter(fn ($value) => $value != null)->map(fn ($value) => Str::of($value)->trim())->toArray();
                 }
 
                 $selected = array_search($field->getName(), $options);


### PR DESCRIPTION
## Proposed changes

When an importing a CSV containing a column heading containing a number, for example `photo_damage_1`, the heading was being mutated to become `photo_damage_`.
Issue was tracked down to be caused by the options collection's `->map('trim')`.

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [ x]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
