### PR TITLE
Have Mass creation actually perform just 1 insert into the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,15 @@ protected function getActions(): array
 }
 ```
 
-### Disable Mass Create
-if you still want to stick with the event model you might need this and turn off mass create
+### Enable Mass Create
+if you can live without model event you can turn this on to enable mass record creation/insertion.
+NOTE: `mutateAfterCreate` will not be applied in this case.
 ```php
 protected function getActions(): array
 {
     return [
         ImportAction::make()
-            ->massCreate(false)
+            ->massCreate(true)
             ->fields([
                 ImportField::make('project')
                     ->label('Project')

--- a/src/Import.php
+++ b/src/Import.php
@@ -211,7 +211,6 @@ class Import
                         $this->doMutateAfterCreate($model, $prepareInsert);
                     } else {
                         $massCreateRecords[] = $prepareInsert;
-                        $model = $this->model::create($prepareInsert);
                     }
                 } else {
                     $closure = $this->handleRecordCreation;

--- a/src/Import.php
+++ b/src/Import.php
@@ -34,7 +34,7 @@ class Import
 
     protected bool $shouldSkipHeader = false;
 
-    protected bool $shouldMassCreate = true;
+    protected bool $shouldMassCreate = false;
 
     protected bool $shouldHandleBlankRows = false;
 

--- a/src/Import.php
+++ b/src/Import.php
@@ -218,7 +218,7 @@ class Import
                 }
             }
 
-            if ($this->shouldMassCreate) {
+            if ($importSuccess && $this->shouldMassCreate) {
                 $this->model::create($massCreateRecords);
             }
         });


### PR DESCRIPTION
## Proposed changes

Mass creation does not actually do mass creation: each record is still created separately.
This PR does:
- changes massCreation default to `false`.
- when massCreation is enabled all records are inserted in one single query to the Database.

Breaking changes:
- massCreation default changed from `true` to `false`.
- `mutateAfterCreate` in not applied when massCreation is enabled

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- []  🛠️ Bug fix (non-breaking change which fixes an issue)
- [X]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [X]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
