### PR TITLE
Feat: Upsert data when an unique field is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,55 @@ protected function getActions(): array
     ];
 }
 ```
+#### Upsert data
+If you want to update data in your application, you can set the `upsert.active` configuration in `config/filament-import.php` to `true`. This will prevent the package from skipping rows that already exist in the database.
+`config/filament-import.php`:
+```php
+'upsert' => [
+    'active' => true,
+]
+```
+##### Upsert using the entire row value
+Here's an example of how to use this feature:
+```php
+ImportAction::make()
+    ->uniqueField('email')
+    ->fields([
+        ImportField::make('name'),
+        ImportField::make('email'),
+        ImportField::make('address'),
+        ->mutateBeforeCreate(function($row){
+            $row['password'] = 'fixed value';
+            return $row;
+        })
+    ])
+```
+In this example, `filament-import` should update the fields `name`, `address`, and `password` of the model that matches the value of the field `email`.
+##### Upsert only the fields defined with `ImportField`
+You can activate the `upsert.only_form_fields` configuration in `config/filament-import.php` to `true` to make the package ignore other fields not listed using `ImportField` (such as those created hardcoded at `mutateBeforeCreate`, for example).
 
+Here's an example of how to use this feature:
+`config/filament-import.php`:
+```php
+'upsert' => [
+    'active' => true,
+    'only_form_fields' => true,
+]
+```
+```php
+ImportAction::make()
+    ->uniqueField('email')
+    ->fields([
+        ImportField::make('name'),
+        ImportField::make('email'),
+        ImportField::make('address'),
+        ->mutateBeforeCreate(function($row){
+            $row['password'] = 'fixed value';
+            return $row;
+        })
+    ])
+```
+In this example, `filament-import` should only update the fields `name` and `address` and ignore `password` for the models that match the value of the field `email`.
 ### Validation
 you can make the validation for import fields, for more information about the available validation please check laravel documentation
 

--- a/config/filament-import.php
+++ b/config/filament-import.php
@@ -13,4 +13,8 @@ return [
         'disk' => 'local',
         'directory' => 'filament-import',
     ],
+    'upsert' => [
+        'active' => false,
+        'only_form_fields' => false
+    ]
 ];

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -3,6 +3,7 @@
 use Konnco\FilamentImport\Tests\Resources\Models\Post;
 use Konnco\FilamentImport\Tests\Resources\Pages\AlternativeColumnsNamesList;
 use Konnco\FilamentImport\Tests\Resources\Pages\HandleCreationList;
+use Konnco\FilamentImport\Tests\Resources\Pages\HandleUpdateList;
 use Konnco\FilamentImport\Tests\Resources\Pages\NonRequiredTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\ValidateTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\WithoutMassCreateTestList;
@@ -136,6 +137,75 @@ it('can match alternative column names', function () {
 
     assertDatabaseCount(Post::class, 11);
 });
+
+it('can handling record update', function (bool $upsert, int $totalRecords) {
+    
+    $file = csvFiles(0, ['New Title', 'Slug', 'New Body']);
+    
+    config()->set('filament-import.upsert.active', $upsert);
+    
+    if($upsert) {
+        $live = livewire(HandleUpdateList::class);
+    } else {
+        $live = livewire(HandleCreationList::class);
+    }
+    
+    $live->mountPageAction('import')
+        ->setPageActionData([
+            'file' => [$file->store('file')],
+            'fileRealPath' => $file->getRealPath(),
+            'title' => 0,
+            'slug' => 1,
+            'body' => 2,
+            'skipHeader' => false,
+        ])
+        ->callMountedPageAction()
+        ->assertHasNoPageActionErrors()
+        ->assertSuccessful();
+
+    assertDatabaseCount(Post::class, $totalRecords);
+
+})->with([
+    ['upsert' => false, 'totalRecords' => 2],
+    ['upsert' => true, 'totalRecords' => 1],
+]);
+
+it('can handling update only form fields', function (bool $only) {
+    
+    config()->set('filament-import.upsert.active', true);
+    config()->set('filament-import.upsert.only_form_fields', $only);
+    
+    if($only === true) {
+        $file = csvFiles(0);
+    } else {
+        $file = csvFiles(0, ['Title', 'Slug', 'New Body']);
+    }
+    
+    livewire(HandleUpdateList::class)->mountPageAction('import')
+        ->setPageActionData([
+            'file' => [$file->store('file')],
+            'fileRealPath' => $file->getRealPath(),
+            'title' => 0,
+            'slug' => 1,
+            'body' => 2,
+            'skipHeader' => false,
+        ])
+        ->callMountedPageAction()
+        ->assertHasNoPageActionErrors()
+        ->assertSuccessful();
+
+    assertDatabaseCount(Post::class, 1);
+
+    if($only === true) {
+        $this->assertSame('Body', Post::first()->body);
+    } else {
+        $this->assertSame('New Body', Post::first()->body);
+    }
+    
+})->with([
+    ['only' => false],
+    ['only' => true]
+]);
 
 //it('can manipulate single field', function () {
 //    expect(true)->toBeTrue();

--- a/tests/Resources/Pages/HandleUpdateList.php
+++ b/tests/Resources/Pages/HandleUpdateList.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Konnco\FilamentImport\Tests\Resources\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Konnco\FilamentImport\Actions\ImportAction;
+use Konnco\FilamentImport\Actions\ImportField;
+use Konnco\FilamentImport\Tests\Resources\Models\Post;
+use Konnco\FilamentImport\Tests\Resources\PostResource;
+
+class HandleUpdateList extends ListRecords
+{
+    protected static string $resource = PostResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            ImportAction::make('import')
+                ->uniqueField('slug')
+                ->fields([
+                    ImportField::make('title'),
+                    ImportField::make('slug'),
+                    ImportField::make('body'),
+                ])
+        ];
+    }
+}


### PR DESCRIPTION
## Proposed changes

Create a feature to give developers the option to activate upsert during the import process. Upsert is set to false by default, but when set to true, it can update records that already exist in the database.

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [X]  ✨ New feature (non-breaking change which adds functionality)
- [ ]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments