### PR TITLE
Fix import with local disks not working after last beta release

### DIFF
--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -165,7 +165,7 @@ class ImportAction extends Action
                 $options = $this->cachedHeadingOptions;
 
                 if (count($options) === 0) {
-                    $options = $this->toCollection($filePath, ! App::runningUnitTests() ? $this->getTemporaryDisk() : null)->first()?->first()->filter(fn ($value) => $value != null)->map('trim')->toArray();
+                    $options = $this->toCollection($filePath, $this->temporaryDiskIsRemote() ? $this->getTemporaryDisk() : null)->first()?->first()->filter(fn ($value) => $value != null)->map('trim')->toArray();
                 }
 
                 $selected = array_search($field->getName(), $options);

--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -12,7 +12,6 @@ use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
-use Illuminate\Support\Facades\App;
 use Konnco\FilamentImport\Concerns\HasActionMutation;
 use Konnco\FilamentImport\Concerns\HasActionUniqueField;
 use Konnco\FilamentImport\Concerns\HasTemporaryDisk;

--- a/src/Concerns/HasTemporaryDisk.php
+++ b/src/Concerns/HasTemporaryDisk.php
@@ -30,4 +30,10 @@ trait HasTemporaryDisk
     {
         $this->temporaryDirectory = $temporaryPath;
     }
+
+    public function temporaryDiskIsRemote(): bool
+    {
+        $driver = config("filesystems.disks.{$this->getTemporaryDisk()}.driver");
+        return in_array($driver, ['s3', 'ftp', 'sftp']);
+    }
 }

--- a/src/Import.php
+++ b/src/Import.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Validator;
 use Konnco\FilamentImport\Actions\ImportField;
 use Konnco\FilamentImport\Concerns\HasActionMutation;
 use Konnco\FilamentImport\Concerns\HasActionUniqueField;
+use Konnco\FilamentImport\Concerns\HasTemporaryDisk;
 use Maatwebsite\Excel\Concerns\Importable;
 
 class Import
@@ -21,6 +22,7 @@ class Import
     use Importable;
     use HasActionMutation;
     use HasActionUniqueField;
+    use HasTemporaryDisk;
 
     protected string $spreadsheet;
 
@@ -104,10 +106,7 @@ class Import
 
     public function getSpreadsheetData(): Collection
     {
-        $driver = config("filesystems.disks.{$this->disk}.driver");
-        $isRemote = in_array($driver, ['s3', 'ftp', 'sftp']);
-
-        $data = $this->toCollection($isRemote ? $this->spreadsheet : new UploadedFile(Storage::disk($this->disk)->path($this->spreadsheet), $this->spreadsheet))
+        $data = $this->toCollection($this->temporaryDiskIsRemote() ? $this->spreadsheet : new UploadedFile(Storage::disk($this->disk)->path($this->spreadsheet), $this->spreadsheet))
             ->first()
             ->skip((int) $this->shouldSkipHeader);
         if (! $this->shouldHandleBlankRows) {


### PR DESCRIPTION
## Proposed changes

Local disk broke with the last update, this fixes it, apparently passing the disk to the ImportAction.php file makes it not work with local disks.

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [ X ]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ X ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ X ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
