### PR TITLE
Feat add accepted mime types in import action

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="14e04d98-ef3b-4469-937a-ec94ab88a343" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ComposerSettings" synchronizationState="SYNCHRONIZE">
+    <pharConfigPath>$PROJECT_DIR$/composer.json</pharConfigPath>
+    <execution />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="PhpWorkspaceProjectConfiguration" interpreter_name="/opt/homebrew/Cellar/php/8.2.7/bin/php" />
+  <component name="ProjectId" id="2WF9qV4L1dXcXde9WXrsXivVoia" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "fix/import-accepted-mime-types",
+    "last_opened_file_path": "/Users/fadilandrian/Documents/Konnco/packages/filament-import",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="14e04d98-ef3b-4469-937a-ec94ab88a343" name="Changes" comment="" />
+      <created>1696317651607</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1696317651607</updated>
+      <workItem from="1696317653481" duration="2101000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -37,6 +37,8 @@ class ImportAction extends Action
 
     protected null|Closure $handleRecordCreation = null;
 
+    protected null|array $acceptedMimeTypes = [];
+
     public static function getDefaultName(): ?string
     {
         return 'import';
@@ -84,7 +86,7 @@ class ImportAction extends Action
             FileUpload::make('file')
                 ->label('')
                 ->required(! app()->environment('testing'))
-                ->acceptedFileTypes(config('filament-import.accepted_mimes'))
+                ->acceptedFileTypes(fn () => $this->acceptedMimeTypes ?: config('filament-import.accepted_mimes'))
                 ->imagePreviewHeight('250')
                 ->reactive()
                 ->disk($this->getTemporaryDisk())
@@ -181,6 +183,13 @@ class ImportAction extends Action
     {
         $this->handleRecordCreation = $closure;
         $this->massCreate(false);
+
+        return $this;
+    }
+
+    public function acceptedMimeTypes(array $mimeType)
+    {
+        $this->acceptedMimeTypes = $mimeType;
 
         return $this;
     }

--- a/src/Actions/ImportAction.php
+++ b/src/Actions/ImportAction.php
@@ -22,10 +22,10 @@ use Maatwebsite\Excel\Concerns\Importable;
 class ImportAction extends Action
 {
     use CanCustomizeProcess;
-    use Importable;
-    use HasTemporaryDisk;
     use HasActionMutation;
     use HasActionUniqueField;
+    use HasTemporaryDisk;
+    use Importable;
 
     protected array $fields = [];
 
@@ -35,9 +35,9 @@ class ImportAction extends Action
 
     protected array $cachedHeadingOptions = [];
 
-    protected null|Closure $handleRecordCreation = null;
+    protected ?Closure $handleRecordCreation = null;
 
-    protected null|array $acceptedMimeTypes = [];
+    protected ?array $acceptedMimeTypes = [];
 
     public static function getDefaultName(): ?string
     {

--- a/src/Actions/ImportField.php
+++ b/src/Actions/ImportField.php
@@ -12,13 +12,13 @@ use Konnco\FilamentImport\Concerns\HasFieldValidation;
 
 class ImportField
 {
-    use HasFieldMutation;
+    use HasColumnMatching;
     use HasFieldHelper;
-    use HasFieldPlaceholder;
     use HasFieldLabel;
+    use HasFieldMutation;
+    use HasFieldPlaceholder;
     use HasFieldRequire;
     use HasFieldValidation;
-    use HasColumnMatching;
 
     public function __construct(private string $name)
     {

--- a/src/Import.php
+++ b/src/Import.php
@@ -18,9 +18,9 @@ use Maatwebsite\Excel\Concerns\Importable;
 
 class Import
 {
-    use Importable;
     use HasActionMutation;
     use HasActionUniqueField;
+    use Importable;
 
     protected string $spreadsheet;
 
@@ -138,7 +138,7 @@ class Import
         return $data;
     }
 
-    public function handleRecordCreation(Closure|null $closure): static
+    public function handleRecordCreation(?Closure $closure): static
     {
         $this->handleRecordCreation = $closure;
 

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -6,6 +6,7 @@ use Konnco\FilamentImport\Tests\Resources\Pages\HandleCreationList;
 use Konnco\FilamentImport\Tests\Resources\Pages\NonRequiredTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\ValidateTestList;
 use Konnco\FilamentImport\Tests\Resources\Pages\WithoutMassCreateTestList;
+
 use function Pest\Laravel\assertDatabaseCount;
 
 it('can render import properly', function () {


### PR DESCRIPTION
fix(ImportAction.php): add support for custom acceptedMimeTypes in the FileUpload component to allow for more flexible file type validation

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Filament Import?
_Put an `x` in the boxes that apply_

- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [ ]  🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ]  ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  🧹 Code refactor
- [ ]  ✅ Build configuration change
- [ ]  📝 Documentation
- [ ]  🗑️ Chore

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
